### PR TITLE
fix vercel deploy 출력값이 GITHUB_OUTPUT에 제대로 저장되지 않음

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -24,7 +24,8 @@ jobs:
         id: deploy
 
         run: |
-          DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > deploy_result.txt
+          DEPLOY_URL=$(cat deploy_result.txt | grep -E "https://.*\.vercel\.app" | head -1 | awk '{print $NF}')
           echo "preview_url=$DEPLOY_URL" >> $GITHUB_OUTPUT
 
       - name: Comment PR with Preview URL


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #61

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
