### PR TITLE
[fix]대시보드 API 자동 호출 주기 설정

### DIFF
--- a/hooks/dashboard/quries/useBarChartQuery.ts
+++ b/hooks/dashboard/quries/useBarChartQuery.ts
@@ -32,8 +32,9 @@ export const useBarChartQuery = (postId: number): UseQueryResult<BarChartRespons
   return useQuery({
     queryKey: queryKeys.dashboard.barChart(postId),
     queryFn: () => getBarChart(postId),
-    staleTime: 1000 * 60 * 5, // 5분 동안 stale 아님
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    staleTime: 0, // 항상 stale로 간주하여 즉시 refetch
+    refetchOnMount: true, // 마운트 시 refetch
+    refetchOnWindowFocus: true, // 윈도우 포커스 시 refetch
+    refetchInterval: 30000, // 30초마다 자동 refetch
   });
 };

--- a/hooks/dashboard/quries/useLineChartQuery.ts
+++ b/hooks/dashboard/quries/useLineChartQuery.ts
@@ -29,8 +29,9 @@ export const useLineChartQuery = (postId: number): UseQueryResult<LineChartRespo
   return useQuery({
     queryKey: queryKeys.dashboard.lineChart(postId),
     queryFn: () => getLineChart(postId),
-    staleTime: 1000 * 60 * 5,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    staleTime: 0, // 항상 stale로 간주하여 즉시 refetch
+    refetchOnMount: true, // 마운트 시 refetch
+    refetchOnWindowFocus: true, // 윈도우 포커스 시 refetch
+    refetchInterval: 30000, // 30초마다 자동 refetch
   });
 };

--- a/hooks/dashboard/quries/usePieChartQuery.ts
+++ b/hooks/dashboard/quries/usePieChartQuery.ts
@@ -30,8 +30,9 @@ export const usePieChartQuery = (postId: number): UseQueryResult<PieChartRespons
   return useQuery({
     queryKey: queryKeys.dashboard.pieChart(postId),
     queryFn: () => getPieChart(postId),
-    staleTime: 1000 * 60 * 5,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    staleTime: 0, // 항상 stale로 간주하여 즉시 refetch
+    refetchOnMount: true, // 마운트 시 refetch
+    refetchOnWindowFocus: true, // 윈도우 포커스 시 refetch
+    refetchInterval: 30000, // 30초마다 자동 refetch
   });
 };

--- a/hooks/dashboard/quries/useStatsQuery.ts
+++ b/hooks/dashboard/quries/useStatsQuery.ts
@@ -32,8 +32,9 @@ export const useStatsQuery = (postId: number): UseQueryResult<StatsResponseModel
   return useQuery({
     queryKey: queryKeys.dashboard.stats(postId),
     queryFn: () => getStats(postId),
-    staleTime: 1000 * 60 * 5, // 5분 동안 stale 아님
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    staleTime: 0, // 항상 stale로 간주하여 즉시 refetch
+    refetchOnMount: true, // 마운트 시 refetch
+    refetchOnWindowFocus: true, // 윈도우 포커스 시 refetch
+    refetchInterval: 30000, // 30초마다 자동 refetch
   });
 };


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #200 
페이지를 다시 방문할 때
브라우저 탭으로 돌아올 때
30초마다 
데이터 갱신하는 로직을 추가함 

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [ ] `main` 브랜치의 최신 코드를 `pull` 받았나요?
